### PR TITLE
Adds babel-cli and moves some dev dependencies to dependencies section.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "devDependencies": {
     "babel-eslint": "5.0.0",
-    "babel-plugin-transform-async-to-module-method": "6.7.0",
-    "babel-polyfill": "6.7.2",
-    "babel-preset-es2015": "6.6.0",
     "babel-register": "6.7.2",
-    "bluebird": "3.3.4",
     "eslint": "2.4.0",
     "estraverse-fb": "1.3.1",
     "mocha": "2.4.5"
+  },
+  "dependencies": {
+    "bluebird": "3.3.4",
+    "babel-cli": "6.6.5",
+    "babel-plugin-transform-async-to-module-method": "6.7.0",
+    "babel-polyfill": "6.7.2",
+    "babel-preset-es2015": "6.6.0"
   }
 }


### PR DESCRIPTION
Babel-cli is added to fix the `src/{client, proxy, server}/index.js` files being callable. This only works if `node_modules/.bin` is added to PATH (and current directory is the root of the project).

Other dependencies (babel dependencies and bluebird) are moved to enable transpilation in a non-dev environment.