### PR TITLE
Use require to load test plots instead of eval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ to work with HTTP proxies.
 Here is an example of using Daft Proxy as a stand-alone program driven by a test
 plot (test mode #1):
 
-    babel src/proxy/plot1.js > src/proxy/plot1.js5 && \
-        ./src/proxy/index.js src/proxy/plot1.js5
+        ./src/proxy/index.js src/proxy/plot1.js
 
 By default, the proxy forwards each message "as is", except for adding the
 required Via header field.
@@ -57,8 +56,7 @@ Daft Client is an HTTP client agent.
 Here is an example of using Daft Client as a stand-alone program driven by a
 test plot (test mode #1):
 
-    babel src/client/plot-raw.js > src/client/plot-raw.js5 && \
-        ./src/client/index.js src/client/plot-raw.js5
+        ./src/client/index.js src/client/plot-raw.js
 
 Daft Client sends an HTTP request to either `localhost:80` or `localhost:8080`,
 depending on whether it is started as root. To customize these details for all

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -10,6 +10,7 @@
  */
 
 import Client from "./Agent";
+import path from "path";
 
 if (process.argv.length !== 3) {
     throw `usage: ${process.argv[1]} <test_plot.js5>`;
@@ -18,13 +19,6 @@ if (process.argv.length !== 3) {
 let fname = process.argv[2];
 console.log("Test plot:", fname);
 
-import fs from "fs";
-fs.readFile(fname, function (err, data) {
-    if (err)
-        throw err;
-
-    eval(data.toString()); // eslint-disable-line no-eval
-
-    let client = new Client();
-    client.start();
-});
+require(path.resolve(fname));
+let client = new Client();
+client.start();

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -10,6 +10,7 @@
  */
 
 import Proxy from "./Agent";
+import path from "path";
 
 if (process.argv.length !== 3)
     throw `usage: ${process.argv[1]} <test_plot.js5>`;
@@ -17,13 +18,6 @@ if (process.argv.length !== 3)
 let fname = process.argv[2];
 console.log("Test plot:", fname);
 
-import fs from "fs";
-fs.readFile(fname, function (err, data) {
-    if (err)
-        throw err;
-
-    eval(data.toString()); // eslint-disable-line no-eval
-
-    let proxy = new Proxy();
-    proxy.start();
-});
+require(path.resolve(fname));
+let proxy = new Proxy();
+proxy.start();

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -10,6 +10,7 @@
  */
 
 import Server from "./Agent";
+import path from "path";
 
 if (process.argv.length !== 3)
     throw `usage: ${process.argv[1]} <test_plot.js5>`;
@@ -17,13 +18,6 @@ if (process.argv.length !== 3)
 let fname = process.argv[2];
 console.log("Test plot:", fname);
 
-import fs from "fs";
-fs.readFile(fname, function (err, data) {
-    if (err)
-        throw err;
-
-    eval(data.toString()); // eslint-disable-line no-eval
-
-    let server = new Server();
-    server.start();
-});
+require(path.resolve(fname));
+let server = new Server();
+server.start();


### PR DESCRIPTION
This provides encapsulation to the test plot, preventing internal details from leaking, and removes the need to read from the file system in daft code.