### PR TITLE
Fix line collapsing.

### DIFF
--- a/src/http/one/MessageParser.js
+++ b/src/http/one/MessageParser.js
@@ -83,8 +83,7 @@ export default class MessageParser {
         header._raw = raw;
 
         // replace obs-fold with a single space
-        let rawH = raw;
-        rawH = rawH.replace(/\r*\n\s+/, ' ');
+        let rawH = raw.replace(/\r*\n\s+/, ' ');
 
         let rawFields = rawH.split('\n');
         Must(rawFields.length); // our caller requires CRLF at the headers end

--- a/src/http/one/MessageParser.js
+++ b/src/http/one/MessageParser.js
@@ -84,8 +84,7 @@ export default class MessageParser {
 
         // replace obs-fold with a single space
         let rawH = raw;
-        // XXX: This does nothing (replace does not change string in place).
-        rawH.replace(/\r*\n\s+/, ' ');
+        rawH = rawH.replace(/\r*\n\s+/, ' ');
 
         let rawFields = rawH.split('\n');
         Must(rawFields.length); // our caller requires CRLF at the headers end


### PR DESCRIPTION
String replace function does not mutate the string it is called upon.