### PR TITLE
Remove double parsing of raw fields.

### DIFF
--- a/src/http/one/MessageParser.js
+++ b/src/http/one/MessageParser.js
@@ -93,8 +93,7 @@ export default class MessageParser {
         for (let rawField of rawFields) {
             let field = this.parseField(rawField + "\n");
             Must(field);
-            // XXX: Use field instead. Do not parse twice.
-            header.fields.push(this.parseField(rawField + "\n"));
+            header.fields.push(field);
         }
 
         if (!header.fields.length)


### PR DESCRIPTION
May be appropriate to consider changing/removing the `Must(field)` check as well, considering that `parseField` always returns a truthy object as it is written right now.