### PR TITLE
Limit server connections/transactions to 1

### DIFF
--- a/src/http/Message.js
+++ b/src/http/Message.js
@@ -126,21 +126,6 @@ export default class Message {
         this.header.finalize(); // after syncContentLength() adds headers
     }
 
-    // copy the 'ID' field from other message
-    copyID(other) {
-        const otherFieldName = other._daftFieldName("ID");
-        if (other.header.has(otherFieldName))
-            this.header.add(otherFieldName, other.header.value(otherFieldName));
-    }
-
-    // returns the 'ID' field value of other message copied to this message (if any)
-    otherID(other) {
-        const otherFieldName = other._daftFieldName("ID");
-        if (this.header.has(otherFieldName))
-            return this.header.value(otherFieldName);
-        return null;
-    }
-
     // returns the 'ID' field value of this message
     id() {
         const fieldName = this._daftFieldName("ID");

--- a/src/http/Message.js
+++ b/src/http/Message.js
@@ -6,6 +6,7 @@
 
 import Authority from "../anyp/Authority";
 import Header from "./Header";
+import Field from "./Field";
 import { Must } from "../misc/Gadgets";
 import * as Config from "../misc/Config";
 import * as Gadgets from "../misc/Gadgets";
@@ -123,6 +124,29 @@ export default class Message {
         this.syncContentLength();
 
         this.header.finalize(); // after syncContentLength() adds headers
+    }
+
+    // copy the 'ID' field from other message
+    copyID(other) {
+        const otherFieldName = other._daftFieldName("ID");
+        if (other.header.has(otherFieldName))
+            this.header.add(otherFieldName, other.header.value(otherFieldName));
+    }
+
+    // returns the 'ID' field value of other message copied to this message (if any)
+    otherID(other) {
+        debugger;
+        const otherFieldName = other._daftFieldName("ID");
+        if (this.header.has(otherFieldName))
+            return this.header.value(otherFieldName);
+        return null;
+    }
+
+    // returns the 'ID' field value of this message
+    id() {
+        const fieldName = this._daftFieldName("ID");
+        if (this.header.has(fieldName))
+            return this.header.value(fieldName);
     }
 
     addBody(body) {

--- a/src/http/Message.js
+++ b/src/http/Message.js
@@ -129,8 +129,8 @@ export default class Message {
     // returns the 'ID' field value of this message
     id() {
         const fieldName = this._daftFieldName("ID");
-        if (this.header.has(fieldName))
-            return this.header.value(fieldName);
+        Must(this.header.has(fieldName));
+        return this.header.value(fieldName);
     }
 
     addBody(body) {

--- a/src/http/Message.js
+++ b/src/http/Message.js
@@ -135,7 +135,6 @@ export default class Message {
 
     // returns the 'ID' field value of other message copied to this message (if any)
     otherID(other) {
-        debugger;
         const otherFieldName = other._daftFieldName("ID");
         if (this.header.has(otherFieldName))
             return this.header.value(otherFieldName);

--- a/src/http/Response.js
+++ b/src/http/Response.js
@@ -72,16 +72,18 @@ export default class Response extends Message {
         return messageWriter.responsePrefix(this);
     }
 
-    // returns the 'ID' field value of the response copied to from the request (if any)
-    extractMatchingId(request) {
+    // The "corresponding Daft request" ID, as stored in response headers (or null).
+    // Daft server transactions store the received Daft request ID when generating responses.
+    requestId(request) {
         const idFieldName = request._daftFieldName("ID");
         if (this.header.has(idFieldName))
             return this.header.value(idFieldName);
         return null;
     }
 
-    // copy the 'ID' field from the received request
-    copyIdFrom(request) {
+    // Copy the Daft request ID field (if any) from the given request.
+    // The requestId() method can be used to extract the copied ID.
+    rememberIdOf(request) {
         const idFieldName = request._daftFieldName("ID");
         if (request.header.has(idFieldName))
             this.header.add(idFieldName, request.header.value(idFieldName));

--- a/src/http/Response.js
+++ b/src/http/Response.js
@@ -85,6 +85,7 @@ export default class Response extends Message {
     // The requestId() method can be used to extract the copied ID.
     rememberIdOf(request) {
         const idFieldName = request._daftFieldName("ID");
+        assert(!this.header.has(idFieldName)); // ban overwriting to simplify triage
         if (request.header.has(idFieldName))
             this.header.add(idFieldName, request.header.value(idFieldName));
     }

--- a/src/http/Response.js
+++ b/src/http/Response.js
@@ -73,7 +73,7 @@ export default class Response extends Message {
     }
 
     // returns the 'ID' field value of the response copied to from the request (if any)
-    copiedResponseId(requst) {
+    extractMatchingId(request) {
         const idFieldName = request._daftFieldName("ID");
         if (this.header.has(idFieldName))
             return this.header.value(idFieldName);
@@ -81,7 +81,7 @@ export default class Response extends Message {
     }
 
     // copy the 'ID' field from the received request
-    copyRequestId(request) {
+    copyIdFrom(request) {
         const idFieldName = request._daftFieldName("ID");
         if (request.header.has(idFieldName))
             this.header.add(idFieldName, request.header.value(idFieldName));

--- a/src/http/Response.js
+++ b/src/http/Response.js
@@ -71,4 +71,19 @@ export default class Response extends Message {
     prefix(messageWriter) {
         return messageWriter.responsePrefix(this);
     }
+
+    // returns the 'ID' field value of the response copied to from the request (if any)
+    copiedResponseId(requst) {
+        const idFieldName = request._daftFieldName("ID");
+        if (this.header.has(idFieldName))
+            return this.header.value(idFieldName);
+        return null;
+    }
+
+    // copy the 'ID' field from the received request
+    copyRequestId(request) {
+        const idFieldName = request._daftFieldName("ID");
+        if (request.header.has(idFieldName))
+            this.header.add(idFieldName, request.header.value(idFieldName));
+    }
 }

--- a/src/overlord/Proxy.js
+++ b/src/overlord/Proxy.js
@@ -317,8 +317,8 @@ export class ProxyOverlord {
             'Overlord-request-path': path,
             'Overlord-active-requests-count': allRequests
         };
-        console.log("Will wait for Proxy to stage " + count + " requests");
-        return this._remoteCall("/waitActiveRequests", options);
+        await this._remoteCall("/waitActiveRequests", options);
+        console.log("Proxy staged " + count + " requests");
     }
 
     _remoteCall(commandOrString, options) {

--- a/src/overlord/Proxy.js
+++ b/src/overlord/Proxy.js
@@ -307,9 +307,11 @@ export class ProxyOverlord {
         console.log("Proxy finished any pending caching transactions");
     }
 
-    waitCollapsed(path, count) {
-        let options = {'Overlord-request-path': path, 'Overlord-collapsed-count': count};
-        return this._remoteCall("/waitCollapsed", options);
+    // count - the number of collapsed requests
+    allCollapsed(path, count) {
+        const allRequests = count + 1; // including the parent request
+        let options = {'Overlord-request-path': path, 'Overlord-active-requests-count': allRequests};
+        return this._remoteCall("/waitActiveRequests", options);
     }
 
     _remoteCall(commandOrString, options) {

--- a/src/overlord/Proxy.js
+++ b/src/overlord/Proxy.js
@@ -290,7 +290,12 @@ export class ProxyOverlord {
         console.log("Proxy finished any pending caching transactions");
     }
 
-    _remoteCall(commandOrString) {
+    waitCollapsed(path, count) {
+        let options = {'Overlord-request-path': path, 'Overlord-collapsed-count': count};
+        return this._remoteCall("/waitCollapsed", options);
+    }
+
+    _remoteCall(commandOrString, options) {
         return new Promise((resolve) => {
 
             const command = ((typeof commandOrString) === 'string') ?
@@ -305,6 +310,9 @@ export class ProxyOverlord {
                     'Pop-Version': 4,
                 },
             };
+
+            if (options)
+                httpOptions.headers = { ...httpOptions.headers, ...options };
 
             httpOptions.headers['Overlord-Listening-Ports'] =
                 this._dutConfig.listeningPorts().join(",");

--- a/src/overlord/Proxy.js
+++ b/src/overlord/Proxy.js
@@ -307,10 +307,17 @@ export class ProxyOverlord {
         console.log("Proxy finished any pending caching transactions");
     }
 
-    // count - the number of collapsed requests
-    allCollapsed(path, count) {
+    // Wait for the proxy to parse the given number of request headers (containing the given URL path)
+    // without satisfying any of those requests.
+    // This only works if the received requests cannot be quickly satisfied by the proxy!
+    // For example, the parsed requests may be waiting for the server(s) to respond.
+    async finishStagingRequests(path, count) {
         const allRequests = count + 1; // including the parent request
-        let options = {'Overlord-request-path': path, 'Overlord-active-requests-count': allRequests};
+        const options = {
+            'Overlord-request-path': path,
+            'Overlord-active-requests-count': allRequests
+        };
+        console.log("Will wait for Proxy to stage " + count + " requests");
         return this._remoteCall("/waitActiveRequests", options);
     }
 
@@ -326,7 +333,7 @@ export class ProxyOverlord {
                 host: "127.0.0.1",
                 port: 13128,
                 headers: {
-                    'Pop-Version': 5,
+                    'Pop-Version': 6,
                 },
             };
 

--- a/src/server/Agent.js
+++ b/src/server/Agent.js
@@ -77,7 +77,7 @@ export default class Agent extends SideAgent {
         });
 
         const addr = Gadgets.FinalizeListeningAddress(this.address());
-        return this.server.listenAsync(addr.port, addr.host);
+        return this.server.listenAsync(addr.port, addr.host).
             bind(this).
             tap(this._startedListening);
     }

--- a/src/server/Transaction.js
+++ b/src/server/Transaction.js
@@ -68,7 +68,7 @@ export default class Transaction extends SideTransaction {
         this.response.header.addByDefault("Server", "DaftServer/1.0");
         this.response.header.addByDefault("Connection", "close");
         this.response.header.addByDefault("Date", new Date().toUTCString());
-        this.response.copyID(this.request);
+        this.response.copyRequestId(this.request);
         this.response.generatorAddress(LocalAddress(this.socket));
         this.response.finalize();
 

--- a/src/server/Transaction.js
+++ b/src/server/Transaction.js
@@ -68,7 +68,7 @@ export default class Transaction extends SideTransaction {
         this.response.header.addByDefault("Server", "DaftServer/1.0");
         this.response.header.addByDefault("Connection", "close");
         this.response.header.addByDefault("Date", new Date().toUTCString());
-        this.response.copyRequestId(this.request);
+        this.response.copyIdFrom(this.request);
         this.response.generatorAddress(LocalAddress(this.socket));
         this.response.finalize();
 

--- a/src/server/Transaction.js
+++ b/src/server/Transaction.js
@@ -68,7 +68,7 @@ export default class Transaction extends SideTransaction {
         this.response.header.addByDefault("Server", "DaftServer/1.0");
         this.response.header.addByDefault("Connection", "close");
         this.response.header.addByDefault("Date", new Date().toUTCString());
-        this.response.copyIdFrom(this.request);
+        this.response.rememberIdOf(this.request);
         this.response.generatorAddress(LocalAddress(this.socket));
         this.response.finalize();
 

--- a/src/server/Transaction.js
+++ b/src/server/Transaction.js
@@ -68,6 +68,7 @@ export default class Transaction extends SideTransaction {
         this.response.header.addByDefault("Server", "DaftServer/1.0");
         this.response.header.addByDefault("Connection", "close");
         this.response.header.addByDefault("Date", new Date().toUTCString());
+        this.response.copyID(this.request);
         this.response.generatorAddress(LocalAddress(this.socket));
         this.response.finalize();
 

--- a/src/side/Agent.js
+++ b/src/side/Agent.js
@@ -84,6 +84,8 @@ export default class Agent {
         }
     }
 
+    finishedTransactions() { return this._xFinished; }
+
     // keeps or closes the socket of a finish()ing transaction
     absorbTransactionSocket(transaction, socket) {
 

--- a/src/side/Agent.js
+++ b/src/side/Agent.js
@@ -84,8 +84,6 @@ export default class Agent {
         }
     }
 
-    finishedTransactions() { return this._xFinished; }
-
     // keeps or closes the socket of a finish()ing transaction
     absorbTransactionSocket(transaction, socket) {
 

--- a/src/side/Transaction.js
+++ b/src/side/Transaction.js
@@ -100,7 +100,7 @@ export default class Transaction {
         this._blockSending('body', externalEvent, waitingFor);
     }
 
-    _blockSending(part, externalEvent, waitingFor) {
+    async _blockSending(part, externalEvent, waitingFor) {
         assert(part in this._sendingBlocks); // valid message part name
         assert(!this._sendingBlocks[part]); // not really needed; may simplify triage
         const block = {
@@ -110,9 +110,8 @@ export default class Transaction {
         };
         this._sendingBlocks[part] = block;
         this.context.log(`will block sending ${block.what} to ${block.waitingFor}`);
-        // convert a (possibly) native Promise, lacking tap() (returned, e.g., by an async function)
-        // to a bluebird Promise
-        Promise.resolve(externalEvent).tap(() => this._unblockSending(part));
+        await externalEvent;
+        this._unblockSending(part);
     }
 
     _unblockSending(part) {

--- a/src/side/Transaction.js
+++ b/src/side/Transaction.js
@@ -110,7 +110,9 @@ export default class Transaction {
         };
         this._sendingBlocks[part] = block;
         this.context.log(`will block sending ${block.what} to ${block.waitingFor}`);
-        externalEvent.tap(() => this._unblockSending(part));
+        // convert a (possibly) native Promise, lacking tap() (returned, e.g., by an async function)
+        // to a bluebird Promise
+        Promise.resolve(externalEvent).tap(() => this._unblockSending(part));
     }
 
     _unblockSending(part) {


### PR DESCRIPTION
This limitation allows to simplify test case logic, especially the ones
testing collapsed (revalidation) forwarding. Also this change should
prevent scenarios when for some reason a transaction gets stuck on
server.closeAsync waiting for all of the server-side sockets to close.

Also added the '/waitActiveRequests' command to Overlord, allowing to
block test execution until all of the required requests have been
'staged' by a proxy.
