### PR TITLE
Replace deprecated node Buffer()

### DIFF
--- a/src/misc/Gadgets.js
+++ b/src/misc/Gadgets.js
@@ -184,7 +184,7 @@ export function SendBytes(socket, bytes, description) {
     Must(arguments.length === 3);
     // bytes must be a "binary" string for the binary conversion in write() to work;
     // for example, the following writes just one byte: write("\u2028", 'binary')
-    Must(Buffer(bytes, "binary").toString("binary") === bytes);
+    Must(Buffer.from(bytes, "binary").toString("binary") === bytes);
     // Even though bytes are in binary format, we must specify "binary" explicitly
     // to avoid *default* conversion to utf8 (that will not work for a binary string!).
     socket.write(bytes, 'binary');

--- a/tests/self.js
+++ b/tests/self.js
@@ -37,7 +37,7 @@ export default class MyTest extends Test {
 
         {
             let testCase = this.makeCase('should not misinterpret HTTP header bytes as utf8 sequences');
-            testCase.client().request.startLine.method = Buffer("G\u2028T").toString("binary");
+            testCase.client().request.startLine.method = Buffer.from("G\u2028T").toString("binary");
             await testCase.run();
         }
 


### PR DESCRIPTION
It is deprecated since v6.0.0, we need to use Buffer.from() instead.